### PR TITLE
10 self heal after large jump in consumption

### DIFF
--- a/custom_components/zen15_cleaner/manifest.json
+++ b/custom_components/zen15_cleaner/manifest.json
@@ -9,5 +9,5 @@
   "integration_type": "hub",
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/NathanWatson/HA-ZEN15-Cleaner/issues",
-  "version": "0.7.7"
+  "version": "0.7.8"
 }

--- a/custom_components/zen15_cleaner/sensor.py
+++ b/custom_components/zen15_cleaner/sensor.py
@@ -30,7 +30,7 @@ from .const import (
     DEFAULT_FORWARD_THRESHOLD_KWH,
     DEFAULT_BACKWARD_THRESHOLD_KWH,
 )
-REJECT_RUN_LIMIT_DEFAULT = 2  # e.g. 12 consecutive rejections ≈ 1 hour at 5-min updates
+REJECT_RUN_LIMIT_DEFAULT = 12  # e.g. 12 consecutive rejections ≈ 1 hour at 5-min updates
 
 
 def _slug(text: str) -> str:


### PR DESCRIPTION
After 12 consecutive rejections (you’ll see reject_run_count climb in attributes), it will adopt the raw value as the new baseline, update the filtered state, and reset the counter.
Close #10 